### PR TITLE
Install scripts for Windows and Linux (possibly macOS / OS X)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 `quantumarticle` is the document class for typsetting articles in Quantum.
 
+## Installing `{quantumarticle}`
+
+The `quantumarticle` class is provided with install scripts for bash and PowerShell. These scripts should work for Windows 7 or later with MiKTeX, or for TeX Live with Linux or macOS / OS X. To install the class into your user-local LaTeX directory from within bash:
+
+```bash
+$ cd quantum-journal/
+$ ./install.sh
+```
+
+Similarly, under PowerShell:
+
+```powershell
+PS > cd quantum-journal/
+PS > ./install.ps1
+```
+
+To manually install ``{quantumarticle}``, copy ``quantumarticle.cls`` to ``texmf/tex/latex/quantumarticle`` within your home directory (``~`` under Linux and macOS / OS X, or typically ``C:\Users\``*``your username``*) under Windows) and run ``texhash`` (TeX Live) or ``initexmf --update-fndb`` (MiKTeX).
+
+To test that the installation completed successfull, copy ``quantum-template.tex`` to another directory and compile it as normal.
+
 ## Usage
 
 To use it, download the latest version of `quantumarticle.cls` from above and put it into the same folder as your main LaTeX source file.

--- a/install.ps1
+++ b/install.ps1
@@ -2,6 +2,39 @@
 ##
 # install.ps1: Installs TeX resources to the current user's TeX directory.
 ##
+# This file is part of quantumarticle.
+#
+#    Copyright (c) 2016 Verein zur Förderung des Open Access Publizierens in
+#    den Quantenwissenschaften (http://quantum-journal.org/about/).
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of quantumarticle, nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
 
 ## TYPES #####################################################################
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,136 @@
+#!/usr/bin/env powershell
+##
+# install.ps1: Installs TeX resources to the current user's TeX directory.
+##
+
+## TYPES #####################################################################
+
+try {
+    Add-Type -TypeDefinition @"
+       public enum TeXDistributions {
+          MiKTeX, Other, None
+       }
+"@
+} catch {}
+
+## FUNCTIONS  ################################################################
+
+function which {
+    param([string] $name)
+
+    try {
+        Get-Command $name -ErrorAction Stop | Select-Object -ExpandProperty Definition
+    } catch {
+        return $null;
+    }
+}
+
+function detect_latex_distribution() {
+    if (!(which("latex"))) {
+        return [TeXDistributions]::None;
+    }
+
+    $version_output = pdflatex --version;
+    $version_header =  $version_output.Split([environment]::NewLine)[0];
+
+    if ($version_header.Contains("MiKTeX")) {
+        return [TeXDistributions]::MiKTeX;
+    } else {
+        return [TeXDistributions]::Other;
+    }
+}
+
+function find_tex_userdir {
+    param([TeXDistributions] $tex_dist = [TeXDistributions]::Other)
+
+    switch ($tex_dist) {
+        "MiKTeX" {
+            $miktex_report = initexmf --report;
+
+            foreach ($report_line in $miktex_report.Split([environment]::NewLine)) {
+                if ($report_line.Contains(":")) {
+                    $key, $value = $report_line.Split(":", 2);
+                    if ($key.ToLower().Trim() -eq "userinstall") {
+                        return $value.Trim();
+                    }
+                }
+            }
+
+            throw [System.IO.FileNotFoundException] "No MiKTeX user install directory found.";
+        }
+
+        "Other" {
+            echo "finding texdir some other way.";
+            break;
+        }
+    }
+
+}
+
+function install_tex_resource {
+    param([string]$source, [string]$tds_path, [string]$tex_userdir)
+
+    $dest = Join-Path -Path $tex_userdir -ChildPath $tds_path;
+
+    # First make sure the TDS path exists.
+    New-Item -ItemType Directory -Path $dest -ErrorAction Ignore;
+
+    # Next, copy the file into the TeX directory.
+    Copy-Item -Path $source -Destination $dest;
+
+}
+
+function refresh_tex_hash {
+    param([TeXDistributions] $tex_dist = [TeXDistributions]::Other)
+    
+    switch ($tex_dist) {
+        "MiKTeX" {
+            initexmf --update-fndb;
+            break;
+        }
+
+        "Other" {
+            texhash -R;
+            break;
+        }
+    }
+
+}
+
+function assert_installed {
+    param([string[]] $sources)
+
+    # Filter out of kpsewhich the current directory (starts with "./",
+    # even on operating systems with \ path separators).
+    foreach ($source in $sources) {
+        $which_output = kpsewhich -all $source;
+        $found = $false;
+
+        foreach ($which_line in $which_output.Split([environment]::NewLine)) {
+            if (-not $which_line.StartsWith("./")) {
+                $found = $true;
+            }
+        }
+
+        if (-not $found) {
+            throw [System.IO.FileNotFoundException] "TeX resource $source not installed sucessfully.";
+        }
+    }
+}
+
+## INSTALL SCRIPT ############################################################
+
+$tex_dist = detect_latex_distribution;
+if ($tex_dist -eq [TeXDistributions]::None) {
+    throw [System.IO.FileNotFoundException] "No LaTeX distribution found. Aborting.";
+}
+
+$tex_userdir = find_tex_userdir -tex_dist $tex_dist;
+
+install_tex_resource -source "quantumarticle.cls" -tds_path "tex/latex/quantumarticle" -tex_userdir $tex_userdir;
+
+refresh_tex_hash -tex_dist $tex_dist;
+
+assert_installed "quantumarticle.cls";
+
+echo "All TeX resources installed successfully.";

--- a/install.ps1
+++ b/install.ps1
@@ -90,7 +90,7 @@ function refresh_tex_hash {
         }
 
         "Other" {
-            texhash -R;
+            texhash;
             break;
         }
     }
@@ -103,7 +103,7 @@ function assert_installed {
     # Filter out of kpsewhich the current directory (starts with "./",
     # even on operating systems with \ path separators).
     foreach ($source in $sources) {
-        $which_output = kpsewhich -all $source;
+        $which_output = kpsewhich -all -progname=pdflatex $source;
         $found = $false;
 
         foreach ($which_line in $which_output.Split([environment]::NewLine)) {

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,39 @@
 ##
 # install.sh: Installs TeX resources to the current user's TeX directory.
 ##
+# This file is part of quantumarticle.
+#
+#    Copyright (c) 2016 Verein zur Förderung des Open Access Publizierens in
+#    den Quantenwissenschaften (http://quantum-journal.org/about/).
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of quantumarticle, nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
 
 ## NOTES #####################################################################
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+##
+# install.sh: Installs TeX resources to the current user's TeX directory.
+##
+
+## NOTES #####################################################################
+
+# We use the idiom documented at
+#     https://www.linuxjournal.com/content/return-values-bash-functions
+# to implement functions with "return values," with the convention that
+# the first argument ($1) to each function is the name of a variable to
+# write the result into.
+
+## FUNCTIONS #################################################################
+
+function detect_latex_distribution() {
+    local __ret_variable=$1
+
+    if [[ -z `which latex` ]]; then
+        eval $__ret_variable="None"
+        return 0
+    fi
+
+    local version_header="$(pdflatex --version | head -n 1)"
+
+    if [[ $version_header == *"MiKTeX"* ]]; then
+        eval $__ret_variable="MiKTeX"
+        return 0
+    elif [[ $version_header == *"TeX Live"* ]]; then
+        eval $__ret_variable="'TeX Live'"
+        return 0
+    else
+        eval $__ret_variable="Other"
+        return 0
+    fi
+}
+
+function find_tex_userdir() {
+    local __ret_variable=$1
+    local tex_dist=$2
+
+    local where_temp=mktemp
+
+    if [[ $tex_dist == "MiKTeX" ]]; then
+        initexmf --report | while read -r line
+        do
+            if [[ $line == *":"* ]]; then
+                if [[ $line =~ 'UserInstall:'(.*) ]]; then
+                    local ret_val="$(echo "$line" | sed -e 's/UserInstall: //')"
+                    printf '%s\n' "$ret_val" > $where_temp
+                fi
+            fi
+        done
+
+        # See https://stackoverflow.com/a/9715377 for why this works.
+        # Specifically, we need the \$ to force escaping of all backslashes.
+        # We may be running under Windows (someone ran bash on Windows to
+        # install a TeX resource? the monster!), such that we must be robust
+        # to \ use here.
+        # Brief addendum: this is ugly beyond all that should ever be permissible.
+        # I'd love a better way to do this.
+        eval $__ret_variable="\$(cat $where_temp)"
+        rm $where_temp
+        return 0
+
+    elif [[ $tex_dist == 'TeX Live' ]]; then
+        eval $__ret_variable="$(kpsewhich --expand-var=\$TEXMFHOME)"
+        return 0
+    elif [[ $tex_dist == "Other" ]]; then
+        eval $__ret_variable="~/texmf/"
+        return 0
+    fi
+
+}
+
+function install_tex_resource() {
+    # No "return" value, so no __ret_variable needed.
+
+    local source="$1"
+    local tds_path="$2"
+    local tex_userdir="$3"
+
+    local dest="$tex_userdir/$tds_path";
+    mkdir -p "$dest"
+    cp "$source" "$dest"
+
+}
+
+function refresh_tex_hash {
+    # No "return" value, so no __ret_variable needed.
+
+    local tex_dist="$1"
+    local tex_userdir="$2"
+    
+    if [[ $tex_dist == "MiKTeX" ]]; then
+        initexmf --update-fndb
+    elif [[ $tex_dist == "Other" ]] || [[ $tex_dist == 'TeX Live' ]]; then
+        texhash "$tex_userdir"
+    fi
+    
+}
+
+function assert_installed() {
+    # No "return" value, so no __ret_variable needed.
+    local source="$1"
+
+    # NB: this is *not* a direct analogy to the function in
+    #     install.ps1, as it does not support multiple arguments at
+    #     once.
+
+    # Filter out of kpsewhich the current directory (starts with "./",
+    # even on operating systems with \ path separators).
+
+    kpsewhich -all -progname=pdflatex "$source" | while read -r line
+    do
+        if [[ $line != "./"* ]]; then
+            return 42
+            break
+        fi
+    done
+
+    local found=$?
+
+    if [[ $found == 0 ]]; then
+        echo "TeX resource $source did not install correctly."
+        return -1
+    elif [[ $found == 42 ]]; then
+        return 0
+    else
+        echo $found
+        echo "Something rather unexpected happened, probably related to while loops being weird."
+        return -9
+    fi
+}
+
+
+## MAIN ######################################################################
+
+function main() {
+
+    detect_latex_distribution tex_dist
+
+    if [[ $tex_dist == "None" ]]; then
+        echo "No LaTeX distribution found."
+        return -1
+    fi
+
+    echo "Using TeX distribution $tex_dist."
+
+    find_tex_userdir tex_userdir "$tex_dist"
+    echo "Using TeX user directory $tex_userdir."
+    install_tex_resource quantumarticle.cls tex/latex/quantumarticle "$tex_userdir"
+
+    refresh_tex_hash "$tex_dist" "$tex_userdir"
+
+    assert_installed quantumarticle.cls
+
+    if [[ $? == 0 ]]; then
+        echo "All TeX resources installed successfully."
+    fi
+
+}
+
+main


### PR DESCRIPTION
To address general complaints about installing LaTeX packages from outside of the MiKTeX package repos or OS-level package managers, this PR adds two new install scripts attempt to automatically find and copy `quantumarticle.cls` into the appropriate directories. Each of the PowerShell and bash install scripts have been tested under the following software environments:
- Windows 10 / MiKTeX
- Windows Subsystem for Linux / Ubuntu 14.04 / TeX Live
- Ubuntu 15.10 / TeX Live

For PowerShell running on the WSL and Linux installations, version 6.0.0alpha was used, while the built-in version was used on Windows 10. In principle, these scripts should also be usable on OS X / macOS, but I don't have a test platform.

Importantly, I have not yet added a copyright header, pending discussion of what an appropriate copyright assignment and license would be for bundled executable scripts. Thanks!
