### PR TITLE
Added the new option 'noarxiv'

### DIFF
--- a/quantumarticle.cls
+++ b/quantumarticle.cls
@@ -219,6 +219,19 @@
 \togglefalse{allowtoday}
 \DeclareOptionX{allowtoday}{\toggletrue{allowtoday}}
 
+\DeclareOptionX{noarxiv}
+{
+	% Sets a4paper, allowfontchangeintitle, allowtoday, nopdfoutputerror and unpublished
+	\setlength\paperheight{297mm}%
+	\setlength\paperwidth{210mm}
+	\toggletrue{papersizespecified}
+	
+	\toggletrue{allowfontchangeintitle}
+	\toggletrue{allowtoday}
+	\toggletrue{nopdfoutputerror}
+	\toggletrue{unpublished}
+}
+
 \ExecuteOptionsX{10pt,oneside,twocolumn,notitlepage,final}
 \ProcessOptionsX
 
@@ -1381,7 +1394,7 @@
 \ifnumequal{\pdfoutput}{0}
 	{}
 	{\PassOptionsToPackage{breaklinks=true}{hyperref}}
-
+	
 %enable DOIs if biblatex is used by default
 \PassOptionsToPackage{doi=true}{biblatex}
 


### PR DESCRIPTION
Added the new option 'noarxiv' that sets the options
	a4paper
	allowfontchangeintitle
	allowtoday
	nopdfoutputerror
	unpublished

to enable seamless use of the template in non-submission scenarios.

This is looking very good. We can already merge it into the refactor branch. Decide yourself if you want to do this now or wait until refactor has been merged into develop.