### PR TITLE
Fix bug that causes the today error to be triggered by empty date

### DIFF
--- a/quantumarticle.cls
+++ b/quantumarticle.cls
@@ -219,6 +219,10 @@ class for Quantum - the open journal for quantum science (http://quantum-journal
 \togglefalse{@allowtoday}
 \DeclareOptionX{allowtoday}{\toggletrue{@allowtoday}}
 
+% set date to be empty as a default, otherwise latex will fill it with \@today which triggers the allowtoday error
+\date{}
+
+
 \DeclareOptionX{noarxiv}
 {
 	\ExecuteOptionsX{a4paper,allowtoday,allowfontchangeintitle,nopdfoutputerror,unpublished}
@@ -455,7 +459,7 @@ class for Quantum - the open journal for quantum science (http://quantum-journal
 	\vskip 1em%
 	\noindent\@printaffiliations
 	\vskip 0em%
-	\noindent{\footnotesize\color{quantumgray}\@date}
+	\ifdefempty{\@date}{}{\noindent{\footnotesize\color{quantumgray}\@date}}%
 	\par
 	\vskip 1.5em
 	\makeatletter%


### PR DESCRIPTION
This solves the issue #77. Here, date is defaulted to empty and a line of code is introduced that doesn't show the date in the title if it is empty.