### PR TITLE
Center title

### DIFF
--- a/quantumarticle.cls
+++ b/quantumarticle.cls
@@ -987,11 +987,10 @@ class for Quantum - the open journal for quantum science (http://quantum-journal
 					{\gdef\@titleforurl{\@titleexpanded}}%
 				%\if@xstring\saveexploremode\exploregroups\StrSubstitute{\@titleexpanded}{ }{\%20}[\@titleforurl]\restoreexploremode\else\gdef\@titleforurl{\@titleexpanded}\fi%
 				\href{http://quantum-journal.org/?s=\@titleforurl\&reason=title-click}{%
-					\begin{minipage}{1.0\linewidth}%
 						\color{quantumviolet}{%
 							\@printtitletextwithappropriatefontsize%
 						}%
-					\end{minipage}}%
+                                              }%
 			}
 		}%
 }
@@ -1029,9 +1028,9 @@ class for Quantum - the open journal for quantum science (http://quantum-journal
 		}%
 	}%
 	\ifdimgreater{\ht\@titelsaveboxHuge}{\ht\@titelsaveboxHugeoneline}
-	{\usebox{\@titelsaveboxhhuge}% using huge because \the\ht\@titelsaveboxHuge{} is larger than \the\ht\@titelsaveboxHugeoneline{}
+	{\@titleatfontsize{\huge}%\usebox{\@titelsaveboxhhuge}% using huge because \the\ht\@titelsaveboxHuge{} is larger than \the\ht\@titelsaveboxHugeoneline{}
 	}
-	{\usebox{\@titelsaveboxHuge}% using Huge because \the\ht\@titelsaveboxHuge{} is not larger than \the\ht\@titelsaveboxHugeoneline{}
+	{\@titleatfontsize{\Huge}% using Huge because \the\ht\@titelsaveboxHuge{} is not larger than \the\ht\@titelsaveboxHugeoneline{}
 	}
 }
 


### PR DESCRIPTION
Fixes #67 by removing a minipage environment and typesetting the title directly instead of using the savebox.