### PR TITLE
CC-BY

### DIFF
--- a/quantumarticle.cls
+++ b/quantumarticle.cls
@@ -1315,7 +1315,7 @@ class for Quantum - the open journal for quantum science (http://quantum-journal
 	\iftoggle{@accepted}
 		{%
 			\newsavebox\@quantumacceptedbox
-			\savebox\@quantumacceptedbox{\textcolor{quantumviolet}{ \sffamily\footnotesize Accepted in {\normalsize\Quantum}\ifcsdef{@accepteddate}{ \@accepteddate}{}, click title to verify}}}
+			\savebox\@quantumacceptedbox{\textcolor{quantumviolet}{ \sffamily\footnotesize Accepted in {\normalsize\Quantum}\ifcsdef{@accepteddate}{ \@accepteddate}{}, click title to verify. Published under CC-BY 4.0.}}}
 		{}
 }
 %elsearticle style extra header information


### PR DESCRIPTION
Adds a human readable notice that the article is has been published under CC-BY to the footline of the article in case the `accepted=` option is used.