### PR TITLE
Fix for bug with line breaks in multi line titles and hyphenation

### DIFF
--- a/quantumarticle.cls
+++ b/quantumarticle.cls
@@ -474,7 +474,11 @@ class for Quantum - the open journal for quantum science (https://quantum-journa
 	\sffamily
 	\null
 	\let \footnote \thanks
-	\noindent{\hyphenpenalty=10000 \@printtitle}
+	\noindent%
+	\begin{minipage}{\textwidth}%
+          \iftoggle{@titlepage}{\centering}{}%
+          \noindent{\huge\hyphenpenalty=5000 \@printtitle\par}%
+        \end{minipage}%
 	\vskip 1.5em%
 	\noindent\@printauthors
 	\vskip 1em%
@@ -1001,24 +1005,21 @@ class for Quantum - the open journal for quantum science (https://quantum-journa
 %title
 \def\@printtitle{%
 	{%
-			\iftoggle{@unpublished}
+			\iftoggle{@unpublished}%
 			{%
-				\begin{minipage}{1.0\linewidth}%
-					\@printtitletextwithappropriatefontsize%
-				\end{minipage}
-			}
+				\@printtitletextwithappropriatefontsize%
+			}%
 			{%
 				\edef\@titleexpanded{\detokenize\expandafter{\@title}}%
-				\iftoggle{@xstring}
-					{\saveexploremode\exploregroups\StrSubstitute{\@titleexpanded}{ }{\%20}[\@titleforurl]\restoreexploremode}
+				\iftoggle{@xstring}%
+					{\saveexploremode\exploregroups\StrSubstitute{\@titleexpanded}{ }{\%20}[\@titleforurl]\restoreexploremode}%
 					{\gdef\@titleforurl{\@titleexpanded}}%
-				%\if@xstring\saveexploremode\exploregroups\StrSubstitute{\@titleexpanded}{ }{\%20}[\@titleforurl]\restoreexploremode\else\gdef\@titleforurl{\@titleexpanded}\fi%
 				\href{https://quantum-journal.org/?s=\@titleforurl\&reason=title-click}{%
 						\color{quantumviolet}{%
-							\@printtitletextwithappropriatefontsize%
+                                                  \@printtitletextwithappropriatefontsize\unskip%
 						}%
                                               }%
-			}
+			}%
 		}%
 }
 % In the macro below we compute the appropriate font size of the title.


### PR DESCRIPTION
Instead of publishing the final version I noticed that we had two rather serious bugs in our release candidate:
1) Because we removed the minipage to get titlepage titles centered, we had incorrect line spacing in multi line titles. I don't understand fully what is going on, but font size changes do not seem to properly set the line spacing if such a font size change is done at the beginning of a line on which then nothing but a `\href` follows after which latex switches back to vertical mode without properly ending a paragraph (you can easily reproduce this by just adding a few words to the quantum-template.tex title). Adding back the minipage (and manually centering inside the minipage in titlepage mode) and adding a `\par` was the only way I could find to work around this.
2) Without the closing `\par` also the `\hyphenpenalty` that we put to discourage hyphens in the title had no effect.

Finally I had to add an `\unskip` as some part of the code (I don't understand which) that sets the title seems to produce some form of white space, which can lead to an ugly new line at the end of titles whose last line exactly fills a page.

I don't want to release without someone giving this a second look...