### PR TITLE
Fix for ltxgrid 4.2e

### DIFF
--- a/quantumarticle.cls
+++ b/quantumarticle.cls
@@ -353,6 +353,9 @@ class for Quantum - the open journal for quantum science (https://quantum-journa
 \let\col@number\@colnum
 
 \ltx@ifpackageloaded{ltxgrid}{
+  \@ifpackagelater{ltxgrid}{2020/10/03}
+  {}% on 2020/10/03 ltxgrid 4.2e (or 4.2d?) was released, which not only fixes the bug we try to work around here but also the fix below causes an error from this version on. 
+  {
 	%repair what ltxutils has destroyed (see https://tex.stackexchange.com/questions/343856/biblatex-produces-incomplete-bcf-with-biber-backend) 
 	\patchcmd\enddocument
 	{\deadcycles}
@@ -366,6 +369,7 @@ class for Quantum - the open journal for quantum science (https://quantum-journa
 				\let\AfterEndDocument\@firstofone
 				\@afterenddocumenthook
 				\etb@@end}}}
+  }
 }{}
 
 \setcounter{topnumber}{2}


### PR DESCRIPTION
Fix for #111 describing a problem with new versions of ltxgrid no longer needing the fix for \AfterEndDocument and at the same time failing with the current fix we have in place.